### PR TITLE
Fixed 1 missing dependency

### DIFF
--- a/intl.mk
+++ b/intl.mk
@@ -19,7 +19,7 @@ translation-edit: ${pot}
 	@$(call _translation_check)
 	@${EDITOR} po/${TRANSLATION_TARGET}/${PACKAGE}.po
 
-translation-update: ${po}
+translation-update: ${po} src/*.c
 	@$(info updating translations)
 	@xgettext -k_ -o ${pot} -i ${src}
 	@mv ${pot}.tmp ${pot}

--- a/intl.mk
+++ b/intl.mk
@@ -19,7 +19,7 @@ translation-edit: ${pot}
 	@$(call _translation_check)
 	@${EDITOR} po/${TRANSLATION_TARGET}/${PACKAGE}.po
 
-translation-update: ${po} src/*.c
+translation-update: ${po} $(SRC)/*.c
 	@$(info updating translations)
 	@xgettext -k_ -o ${pot} -i ${src}
 	@mv ${pot}.tmp ${pot}

--- a/intl.mk
+++ b/intl.mk
@@ -19,7 +19,7 @@ translation-edit: ${pot}
 	@$(call _translation_check)
 	@${EDITOR} po/${TRANSLATION_TARGET}/${PACKAGE}.po
 
-translation-update: ${po} $(SRC)/*.c
+translation-update: ${po} ${src}/*.c
 	@$(info updating translations)
 	@xgettext -k_ -o ${pot} -i ${src}
 	@mv ${pot}.tmp ${pot}


### PR DESCRIPTION
Hi, I've fixed 1 missing dependency reported.
Those issues can cause incorrect results when `gwion-util` is incrementally built.
The target `translate-update` is dependent on the source files in the `src` directory, and these source files are read by the processes when `translate-update` is built. However, they are not specified as the prerequisites of it in the Makefile and some relevant build scripts.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake